### PR TITLE
0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.1] - 2022-03-27
+## [0.2.0-beta.1] - 2022-04-22
+
+### Added
+
+- **A `UserWarning` is issued, if a log function is called with `traceback=True` (or `tb=True`) but there's _no_ exception.**
+- **`Logger.is_enabled_for` issues a `UserWarning`, if `Logger.threshold` is not a `Level`, and it tries to convert it.**
+
 ### Changed
+
+- **Changed how inheritence works**
+- Protocols are now runtime checkable.
+
+### Removed
+
+- **! Because inheritence changed, most of the `get_*` methods were _removed_.**
+
+## [0.1.1] - 2022-03-27
+
+### Changed
+
 - Uncommented lots of stuff in `setup.cfg`
 - Added `.vscode` into `.gitignore`
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mylog
 
-[![Codacy Badge](https://app.codacy.com/project/badge/Grade/60939547f7b344bea1094f4c90ee69bb)](https://www.codacy.com/gh/koviubi56/mylog/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=koviubi56/mylog&amp;utm_campaign=Badge_Grade)
+[![Codacy Badge](https://app.codacy.com/project/badge/Grade/60939547f7b344bea1094f4c90ee69bb)](https://www.codacy.com/gh/koviubi56/mylog/dashboard?utm_source=github.com&utm_medium=referral&utm_content=koviubi56/mylog&utm_campaign=Badge_Grade)
 [![CodeFactor](https://www.codefactor.io/repository/github/koviubi56/mylog/badge)](https://www.codefactor.io/repository/github/koviubi56/mylog)
 [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/koviubi56/mylog/main.svg)](https://results.pre-commit.ci/latest/github/koviubi56/mylog/main)
 [![Build Status](https://app.travis-ci.com/koviubi56/mylog.svg?branch=main)](https://app.travis-ci.com/koviubi56/mylog)
@@ -42,6 +42,10 @@ logger.info("Hello, world!")
 
 **WARNING!** If you see a `-` (minus/dash/hyphen) in an argument name, **it is a `_` (underscore)!**
 
+### _variable_ `__version__`
+
+The version string of the library.
+
 ### _constant_ `DEFAULT_FORMAT`
 
 The default format used by MyLog.
@@ -69,15 +73,35 @@ Aliases:
 The default threshold used by MyLog.
 By default it is `Level.warning`.
 
-### _function_ `to_level`(lvl: _Levelable_) -> _Level_
+### _protocol_ `Stringable`
 
-Converts an int/str/something to a Level.
+A class that has a `__str__` method, that returns a string.
+
+### _type alias_ `Levelable`
+
+```py
+Union[Level, Stringable, int]
+```
+
+### _function_ `to_level`(lvl: _Levelable_, int-ok: _bool_ = False) -> _Level_
+
+Converts an int/str/something to a Level. If `lvl` cannot be converted, and `int_ok` is True, the int will be returned.
+
+### _protocol_ `Lock`
+
+A class that has a `__enter__` and `__exit__` method.
 
 ### _class_ `NoLock`(blocking: _bool_ = True, timeout: _float_ = -1)
 
 A "Lock" that does nothing.
 
-### _class_ `LogEvent`(msg: _str_, level: _Level_, time: _int_, indent: _int_, frame-depth: _int_)
+### _type alias_ `NoneType`
+
+```py
+type(None)
+```
+
+### _class_ `LogEvent`(msg: _str_, level: _Level_, time: _float_, indent: _int_, frame-depth: _int_)
 
 A log event.
 Time is in UNIX seconds.
@@ -92,7 +116,17 @@ The logger class.
 
 Should level_to_str use colors? Defaults to `True`.
 
+#### Static methods
+
+##### `_color`(rv: _str_) -> _str_
+
+Colorizes a string.
+
 #### Methods
+
+##### `_inherit_`(lock: _Optional[Lock]_) -> _None_
+
+Inherit from `self.higher` (_"parent"_).
 
 ##### `level_to_str`(lvl: _Levelable_) -> _str_
 
@@ -101,6 +135,10 @@ Convert a level to a string.
 ##### `format_msg`(lvl: _Levelable_, msg: _Stringable_, tb: _bool_, frame-depth: _int_) -> _str_
 
 Format the message.
+
+##### `_log`(lvl: _Levelable_, msg: _Stringable_, tb: _bool_, frame-depth: _int_) -> _int_
+
+Log a message.
 
 ##### `debug`/`info`/`warning`/`error`/`critical`(msg: _Stringable_, traceback: _bool_ = False) -> _int_
 
@@ -114,14 +152,13 @@ Get a child logger.
 
 Check if the logger is enabled for the given level.
 
-##### `get_effective_level`/`get_format`/`get_enabled`/`get_stream`/`get_indent`()
-
-Get one of the logger's attribute.
-It returns (respectively) `Level`, `str`, `bool`, `IO[str]`, `int`.
-
 ### _context manager_ `IndentLogger`(logger: _Logger_)
 
 Indent the logger by one when entered, then unindent by one when exited.
+
+### _context manager_ `ChangeThreshold`(logger: _Logger_, level: _Levelable_)
+
+Change the threshold of the logger to `level` when entered, then restore the threshold when exited.
 
 ### _variable_ `root`
 

--- a/bandit.yml
+++ b/bandit.yml
@@ -1,3 +1,5 @@
 # https://github.com/PyCQA/bandit/pull/450#issuecomment-724777229
 assert_used:
     skips: ["*/test_*.py"]
+random:
+    skips: ["*/test_*.py"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,5 +34,7 @@ zip_safe = no
 mylog = py.typed
 
 [flake8]
-extend-ignore = E501,S101,W503
+extend-ignore = E501,W503
 extend-exclude = venv,*cache*
+per-file-ignores =
+    test_*.py: S101,DUO102,S311

--- a/src/mylog/__init__.py
+++ b/src/mylog/__init__.py
@@ -45,7 +45,7 @@ from warnings import warn
 
 import termcolor
 
-__version__ = "0.2.0-beta.1"
+__version__ = "0.2.0"
 
 T = TypeVar("T")
 DEFAULT_FORMAT = "[{lvl} {time} line: {line}] {indent}{msg}"

--- a/src/mylog/__init__.py
+++ b/src/mylog/__init__.py
@@ -45,7 +45,7 @@ from warnings import warn
 
 import termcolor
 
-__version__ = "0.1.1"
+__version__ = "0.2.0-beta.1"
 
 T = TypeVar("T")
 DEFAULT_FORMAT = "[{lvl} {time} line: {line}] {indent}{msg}"

--- a/src/mylog/__init__.py
+++ b/src/mylog/__init__.py
@@ -193,7 +193,6 @@ def is_union(union: Any) -> bool:
         return (
             (type(union) is Union)
             or (union.__origin__ is Union)
-            or (type(union))
         )
     except AttributeError:
         return False

--- a/src/mylog/__init__.py
+++ b/src/mylog/__init__.py
@@ -301,7 +301,6 @@ class Logger:
             str: The colorized string.
         """
         check_types(rv=(str, rv))
-        rv = rv.strip()
         if rv == "DEBUG":
             rv = termcolor.colored("DEBUG".ljust(8), "blue")
         elif rv == "INFO":
@@ -333,7 +332,7 @@ class Logger:
         try:
             rv = to_level(lvl, False).name.upper()  # type: ignore
         except (ValueError, AttributeError):
-            rv = str(lvl)
+            rv = str(lvl).ljust(8)
 
         if rv == "WARN":
             rv = "WARNING"

--- a/src/mylog/__init__.py
+++ b/src/mylog/__init__.py
@@ -268,7 +268,7 @@ class Logger:
         if isinstance(
             __o, Logger  # Hardcoded, because class can be subclassed
         ):
-            return self._id == __o._id  # type: ignore
+            return self._id == __o._id
         return NotImplemented
 
     def __ne__(self, __o: object) -> bool:
@@ -276,7 +276,7 @@ class Logger:
         if isinstance(
             __o, Logger  # Hardcoded, because class can be subclassed
         ):
-            return self._id != __o._id  # type: ignore
+            return self._id != __o._id
         return NotImplemented
 
     def _inherit(self, lock: Optional[Lock]) -> None:
@@ -391,9 +391,9 @@ class Logger:
         except (ValueError, AttributeError):
             rv = str(lvl).ljust(8)
 
-        if rv == "WARN":
+        if rv == "WARN":  # pragma: no cover
             rv = "WARNING"
-        if rv == "FATAL":
+        if rv == "FATAL":  # pragma: no cover
             rv = "CRITICAL"
 
         if self.colors:
@@ -693,8 +693,6 @@ class IndentLogger:
         Returns:
             int: The logger's indent
         """
-        if self.logger.indent is None:
-            self.logger.indent = self.logger.get_indent()
         self.logger.indent += 1
         return self.logger.indent
 

--- a/src/mylog/__init__.py
+++ b/src/mylog/__init__.py
@@ -569,7 +569,7 @@ class Logger:
         # (That's why we have `._inherit`)
         cls: Type[Logger] = type(self)
         rv = cls(self)
-        rv._inherit()
+        rv._inherit(None)
         return rv
 
     def is_enabled_for(self, lvl: Levelable) -> bool:

--- a/tests/test_mylog.py
+++ b/tests/test_mylog.py
@@ -311,7 +311,7 @@ def test_nolock():
     nolock = mylog.NoLock()
 
     assert nolock.__enter__() in {True, False, 1}
-    assert nolock.__exit__() is None
+    assert nolock.__exit__(None, None, None) is None
 
 
 def test_nonetype():
@@ -639,7 +639,9 @@ class TestLogger:
         assert logger.is_enabled_for(mylog.Level.critical)
 
         logger.threshold = "fatal"
-        with pytest.warns(UserWarning, match="Logger threshold should be a Level"):
+        with pytest.warns(
+            UserWarning, match="Logger threshold should be a Level"
+        ):
             logger.is_enabled_for(mylog.Level.critical)
 
     @staticmethod

--- a/tests/test_mylog.py
+++ b/tests/test_mylog.py
@@ -44,7 +44,7 @@ def _random_int(
 
 
 def _random_bytes(
-    *, only_if: Callable[[int], bool] = lambda _: True
+    *, only_if: Callable[[bytes], bool] = lambda _: True
 ) -> bytes:
     rv = _randbytes(_random_int(False))
     if only_if(rv):

--- a/tests/test_mylog.py
+++ b/tests/test_mylog.py
@@ -89,7 +89,7 @@ def _random_level() -> Tuple[
 
 
 def random_anything(
-    *, only_if: Callable[[int], bool] = lambda _: True
+    *, only_if: Callable[[Union[bytes, int, str]], bool] = lambda _: True
 ) -> Union[str, bytes, int]:
     rt = _randchoice(("hex", "bytes", "urlsafe", "int"))
     if rt == "hex":

--- a/tests/test_mylog.py
+++ b/tests/test_mylog.py
@@ -53,7 +53,7 @@ def _random_bytes(
 
 
 def _random_urlsafe(
-    *, only_if: Callable[[int], bool] = lambda _: True
+    *, only_if: Callable[[str], bool] = lambda _: True
 ) -> str:
     tok = _random_bytes()
     rv = base64.urlsafe_b64encode(tok).rstrip(b"=").decode("ascii")

--- a/tests/test_mylog.py
+++ b/tests/test_mylog.py
@@ -1,255 +1,644 @@
+import base64
+import os
 import secrets
+import sys
+from time import time as get_unix_time
+from typing import Callable, Sequence, Tuple, TypeVar, Union
 
 import pytest
+import termcolor
 
 import mylog
 
-
-def test_nolock_enter():
-    nl = mylog.NoLock()
-
-    enter_rv = nl.__enter__()
-
-    assert isinstance(enter_rv, bool) or enter_rv == 1
+T = TypeVar("T")
 
 
-def test_nolock_exit():
-    nl = mylog.NoLock()
+def _randint(a: int, b: int) -> int:
+    # random.randint is used only here,
+    # so we have to use "nosec" (vvvvvvvvvvvv) only once
+    return secrets.SystemRandom().randint(a, b)  # nosec B311
 
-    exit_rv = nl.__exit__(None, None, None)
 
-    assert exit_rv is None
+def _randbytes(length: int) -> bytes:
+    # random.randbytes is used only here,
+    # so we have to use "nosec" only once
+    return secrets.SystemRandom().randbytes(length)  # nosec B311
+
+
+def _randchoice(seq: Sequence[T]) -> T:
+    # random.choice is used only here,
+    # so we have to use "nosec" only once
+    return secrets.SystemRandom().choice(seq)  # nosec B311
+
+
+def _random_int(
+    neg_ok: bool, *, only_if: Callable[[int], bool] = lambda _: True
+) -> int:
+    # sourcery skip: assign-if-exp, reintroduce-else
+    if neg_ok:
+        rv = _randint(-50, 50)
+    rv = _randint(0, 100)
+    if only_if(rv):
+        return rv
+    return _random_int(neg_ok, only_if=only_if)
+
+
+def _random_bytes(
+    *, only_if: Callable[[int], bool] = lambda _: True
+) -> bytes:
+    rv = _randbytes(_random_int(False))
+    if only_if(rv):
+        return rv
+    return _random_bytes(only_if=only_if)
+
+
+def _random_urlsafe(
+    *, only_if: Callable[[int], bool] = lambda _: True
+) -> str:
+    tok = _random_bytes()
+    rv = base64.urlsafe_b64encode(tok).rstrip(b"=").decode("ascii")
+    if only_if(rv):
+        return rv
+    return _random_urlsafe(only_if=only_if)
+
+
+def _random_nonlevel_int(
+    *, only_if: Callable[[int], bool] = lambda _: True
+) -> int:
+    rv = _random_int(
+        True,
+        only_if=lambda num: num not in {10, 20, 30, 40, 50},
+    )
+    if only_if(rv):
+        return rv
+    return _random_nonlevel_int(only_if=only_if)
+
+
+def _random_level() -> Tuple[
+    Union[mylog.Level, int, str], mylog.Level
+]:
+    lvl = _randchoice(tuple(mylog.Level))
+    _to = _randchoice(("lvl", "int", "str"))
+    if _to == "lvl":
+        return lvl, lvl
+    elif _to == "int":
+        return lvl.value, lvl
+    elif _to == "str":
+        return lvl.name, lvl
+    # else is not needed
+
+
+def _random_bool() -> bool:
+    return _randchoice((True, False))
+
+
+def random_anything(
+    *, only_if: Callable[[int], bool] = lambda _: True
+) -> Union[str, bytes, int]:
+    rt = _randchoice(("hex", "bytes", "urlsafe", "int"))
+    if rt == "hex":
+        rv = _random_bytes().hex()
+    elif rt == "bytes":
+        rv = _random_bytes()
+    elif rt == "urlsafe":
+        rv = _random_urlsafe()
+    elif rt == "int":
+        rv = _random_int(True)
+    # else is not needed
+    if only_if(rv):
+        return rv
+    return random_anything(only_if=only_if)
+
+
+def x_is_y(x: object, y: object) -> bool:
+    # So we don't get "do not compare types, use 'isinstance()' flake8(E721)"
+    return x is y
+
+
+def x_equals_y(x: object, y: object) -> bool:
+    # So we test "==" AND "__eq__"
+    return (x == y) and (x.__eq__(y))
+
+
+def x_not_equals_y(x: object, y: object) -> bool:
+    # So we test "!=" AND "__ne__"
+    return (x != y) and (x.__ne__(y))
+
+
+def speed() -> float:
+    start = get_unix_time()
+    logger = mylog.root.get_child()
+    logger.threshold = mylog.Level(10)
+    logger.stream = open(os.devnull, "w")
+    logger.critical(
+        "The quick brown fox jumps over the lazy dog.", False
+    )
+    end = get_unix_time()
+    return end - start
+
+
+def skip_if_slow():
+    if (spd := speed()) >= 1:
+        pytest.skip(
+            f"This computer is too slow. A few simple stuff took {spd}"
+            " seconds, while it should be less then one second."
+        )
+
+
+def test_to_level():
+    assert mylog.to_level(mylog.Level.debug) == mylog.Level.debug
+    assert mylog.to_level(mylog.Level.info) == mylog.Level.info
+    assert mylog.to_level(mylog.Level.warning) == mylog.Level.warning
+    assert mylog.to_level(mylog.Level.warn) == mylog.Level.warning
+    assert mylog.to_level(mylog.Level.error) == mylog.Level.error
+    assert (
+        mylog.to_level(mylog.Level.critical) == mylog.Level.critical
+    )
+    assert mylog.to_level(mylog.Level.fatal) == mylog.Level.critical
+
+    assert (
+        mylog.to_level(mylog.Level.debug.numerator)
+        == mylog.Level.debug
+    )
+    assert (
+        mylog.to_level(mylog.Level.info.numerator) == mylog.Level.info
+    )
+    assert (
+        mylog.to_level(mylog.Level.warning.numerator)
+        == mylog.Level.warning
+    )
+    assert (
+        mylog.to_level(mylog.Level.warn.numerator)
+        == mylog.Level.warning
+    )
+    assert (
+        mylog.to_level(mylog.Level.error.numerator)
+        == mylog.Level.error
+    )
+    assert (
+        mylog.to_level(mylog.Level.critical.numerator)
+        == mylog.Level.critical
+    )
+    assert (
+        mylog.to_level(mylog.Level.fatal.numerator)
+        == mylog.Level.critical
+    )
+
+    assert (
+        mylog.to_level(mylog.Level.debug.value) == mylog.Level.debug
+    )
+    assert mylog.to_level(mylog.Level.info.value) == mylog.Level.info
+    assert (
+        mylog.to_level(mylog.Level.warning.value)
+        == mylog.Level.warning
+    )
+    assert (
+        mylog.to_level(mylog.Level.warn.value) == mylog.Level.warning
+    )
+    assert (
+        mylog.to_level(mylog.Level.error.value) == mylog.Level.error
+    )
+    assert (
+        mylog.to_level(mylog.Level.critical.value)
+        == mylog.Level.critical
+    )
+    assert (
+        mylog.to_level(mylog.Level.fatal.value)
+        == mylog.Level.critical
+    )
+
+    assert (
+        mylog.to_level(str(mylog.Level.debug.numerator))
+        == mylog.Level.debug
+    )
+    assert (
+        mylog.to_level(str(mylog.Level.info.numerator))
+        == mylog.Level.info
+    )
+    assert (
+        mylog.to_level(str(mylog.Level.warning.numerator))
+        == mylog.Level.warning
+    )
+    assert (
+        mylog.to_level(str(mylog.Level.warn.numerator))
+        == mylog.Level.warning
+    )
+    assert (
+        mylog.to_level(str(mylog.Level.error.numerator))
+        == mylog.Level.error
+    )
+    assert (
+        mylog.to_level(str(mylog.Level.critical.numerator))
+        == mylog.Level.critical
+    )
+    assert (
+        mylog.to_level(str(mylog.Level.fatal.numerator))
+        == mylog.Level.critical
+    )
+
+    assert (
+        mylog.to_level(str(mylog.Level.debug.value))
+        == mylog.Level.debug
+    )
+    assert (
+        mylog.to_level(str(mylog.Level.info.value))
+        == mylog.Level.info
+    )
+    assert (
+        mylog.to_level(str(mylog.Level.warning.value))
+        == mylog.Level.warning
+    )
+    assert (
+        mylog.to_level(str(mylog.Level.warn.value))
+        == mylog.Level.warning
+    )
+    assert (
+        mylog.to_level(str(mylog.Level.error.value))
+        == mylog.Level.error
+    )
+    assert (
+        mylog.to_level(str(mylog.Level.critical.value))
+        == mylog.Level.critical
+    )
+    assert (
+        mylog.to_level(str(mylog.Level.fatal.value))
+        == mylog.Level.critical
+    )
+
+    assert mylog.to_level(mylog.Level.debug.name) == mylog.Level.debug
+    assert mylog.to_level(mylog.Level.info.name) == mylog.Level.info
+    assert (
+        mylog.to_level(mylog.Level.warning.name)
+        == mylog.Level.warning
+    )
+    assert (
+        mylog.to_level(mylog.Level.warn.name) == mylog.Level.warning
+    )
+    assert mylog.to_level(mylog.Level.error.name) == mylog.Level.error
+    assert (
+        mylog.to_level(mylog.Level.critical.name)
+        == mylog.Level.critical
+    )
+    assert (
+        mylog.to_level(mylog.Level.fatal.name) == mylog.Level.critical
+    )
+
+    with pytest.raises(ValueError, match="Invalid level"):
+        mylog.to_level(_random_nonlevel_int())
+
+    with pytest.raises(ValueError, match="Invalid level"):
+        mylog.to_level(
+            _random_urlsafe(
+                # Relatively unlikely
+                only_if=lambda x: x
+                not in {
+                    "debug",
+                    "info",
+                    "warn",
+                    "warning",
+                    "error",
+                    "critical",
+                    "fatal",
+                }
+            )
+        )
+
+    with pytest.raises(ValueError, match="Invalid level"):
+        mylog.to_level(_random_bytes())
+
+    nli = _random_nonlevel_int()
+    # ↪ Non-level int
+    assert mylog.to_level(nli, True) == nli
+
+
+def tets_nolock():
+    nolock = mylog.NoLock()
+
+    assert nolock.__enter__() in {True, False, 1}
+    assert nolock.__exit__() is None
+
+
+def test_nonetype():
+    assert x_is_y(mylog.NoneType, type(None))
 
 
 def test_check_types():
-    assert mylog.check_types(a=(int, 1), b=(str, "2"))
-    assert mylog.check_types(
-        arg_1=((int, float), 1), b_8=(str, "Hello world")
+    assert mylog.check_types(a=(int, 1), b=(str, "2")) is True
+    assert (
+        mylog.check_types(
+            arg_1=((int, float), 1), b_8=(str, "Hello world")
+        )
+        is True
     )
-    assert mylog.check_types(do=(bool, True))
+    assert mylog.check_types(do=(bool, True)) is True
     with pytest.raises(
         TypeError,
-        match="'do' must be type <class 'bool'>, got <class 'NoneType'>"
+        match=r"'do' must be type <class 'bool'>, got <class 'NoneType'>"
         r" \(None\)",
     ):
-        mylog.check_types(do=(bool, None))  # !
+        mylog.check_types(do=(bool, None))
     with pytest.raises(
         TypeError,
         match=r"'sure' must be type \(<class 'bool'>, <class 'int'>\), got"
         r" <class 'float'> \(6.9\)",
     ):
-        mylog.check_types(
-            do=(bool, False), sure=((bool, int), 6.9)
-        )  # !
+        mylog.check_types(do=(bool, False), sure=((bool, int), 6.9))
 
 
-def test_logger_does_not_allow_root():
-    with pytest.raises(
-        ValueError,
-        match="Cannot create a new logger: Root logger already"
-        " exists. Use that, or make a child logger from the root"
-        " one.",
-    ):
-        mylog.Logger()
-
-
-def anyting_except(exc: type) -> object:
-    while True:
-        r = secrets.choice(
-            (
-                "str",
-                "int",
-                "float",
-                "bool",
-                "None",
-                "list",
-                "tuple",
-                "dict",
-                "set",
-                "frozenset",
-                "bytes",
-                "bytearray",
-            )
-        )
-        if r == exc:
-            continue
-        if r == "str":
-            return secrets.token_urlsafe()
-        if r == "int":
-            return secrets.randbelow(int(1e6))
-        if r == "float":
-            return secrets.SystemRandom().uniform(0, int(1e6))
-        if r == "bool":
-            return secrets.choice((True, False))
-        if r == "None":
-            return None
-        if r == "list":
-            return [
-                anyting_except("{NULL}")
-                for _ in range(secrets.randbelow(5))
-            ]
-        if r == "tuple":
-            return tuple(
-                anyting_except("{NULL}")
-                for _ in range(secrets.randbelow(5))
-            )
-        if r == "dict":
-            return {
-                secrets.token_urlsafe(): anyting_except("{NULL}")
-                for _ in range(secrets.randbelow(5))
-            }
-        if r == "set":
-            return {
-                secrets.token_urlsafe()
-                for _ in range(secrets.randbelow(5))
-            }
-        if r == "frozenset":
-            return frozenset(
-                secrets.token_urlsafe()
-                for _ in range(secrets.randbelow(5))
-            )
-        if r == "bytes":
-            return secrets.token_bytes()
-        if r == "bytearray":
-            return bytearray(secrets.token_bytes())
-
-
-def test_logger_root_propagate():
-    mylog.root.propagate = True
-    with pytest.warns(
-        UserWarning,
-        match="Root logger should not propagate! Set enabled to"
-        " False if you want to disable it.",
-    ):
-        mylog.root.debug("Test")
-    mylog.root.propagate = False
-
-
-def test_logger_get_child():
-    root = mylog.root
-    child = root.get_child()
-    assert child.higher == root
-    assert child.colors == root.colors
-    assert child.enabled is None
-    assert child.format is None
-    assert child.indent is None
-    assert child.propagate is False
-    assert child.stream is None
-    assert child.threshold is None
-
-
-# self is not needed
-def no_format_msg(lvl, msg, tb, frame_depth):
-    return ""
-
-
-class TestLoggerList:
+class TestLogger:
     @staticmethod
-    def logger_factory():
-        return mylog.root.get_child()
+    def test_eq():
+        l1 = l2 = mylog.root.get_child()
+        assert x_equals_y(l1, l2)
+        assert x_equals_y(l2, l1)
+        assert x_equals_y(mylog.root, mylog.root)
 
-    def test_new(self):
-        mylogger = self.logger_factory()
+    @staticmethod
+    def test_ne():
+        l1 = mylog.root.get_child()
+        l2 = mylog.root.get_child()
+        assert x_not_equals_y(l1, l2)
+        assert x_not_equals_y(l2, l1)
 
-        assert mylogger.get_enabled() is True
-        assert mylogger.list == []
+    @staticmethod
+    def test_init():
+        lock = mylog.NoLock()
+        # Don't set `_allow_root` in production code
+        mylog._allow_root = True
+        logger = mylog.Logger(None, lock=lock)
+        mylog._allow_root = False
 
-    def test_success(self):
-        mylogger = self.logger_factory()
-        mylogger.format_msg = no_format_msg
+        assert logger.higher is None
+        assert logger.propagate is False
+        assert logger.lock == lock
+        assert logger.list == []
 
-        stuff = str(anyting_except("{NULL}"))
-        mylogger.critical(stuff)
+        assert logger.format == mylog.DEFAULT_FORMAT
+        assert logger.threshold == mylog.DEFAULT_THRESHOLD
+        assert logger.enabled is True
+        assert logger.stream == sys.stdout
+        assert logger.indent == 0
 
-        assert len(mylogger.list) == 1
+    @staticmethod
+    def test_color():
+        logger = mylog.root
+        assert logger._color("quick brown fox") == "quick brown fox"
+        assert logger._color("DEBUG") == termcolor.colored(
+            "DEBUG".ljust(8), "blue"
+        )
+        assert logger._color("INFO") == termcolor.colored(
+            "INFO".ljust(8), "cyan"
+        )
+        assert logger._color("WARNING") == termcolor.colored(
+            "WARNING".ljust(8), "yellow"
+        )
+        assert logger._color("ERROR") == termcolor.colored(
+            "ERROR".ljust(8), "red"
+        )
+        assert logger._color("CRITICAL") == termcolor.colored(
+            "CRITICAL".ljust(8),
+            "red",
+            "on_yellow",
+            ["bold", "underline", "blink"],
+        )
 
-        logevent = mylogger.list[0]
-        self.check_log_event(logevent, stuff)
+    @staticmethod
+    def test_level_to_string():
+        logger = mylog.root
+        assert logger.level_to_str(
+            mylog.Level.debug
+        ) == termcolor.colored("DEBUG".ljust(8), "blue")
+        assert logger.level_to_str(
+            mylog.Level.info
+        ) == termcolor.colored("INFO".ljust(8), "cyan")
+        assert logger.level_to_str(
+            mylog.Level.warning
+        ) == termcolor.colored("WARNING".ljust(8), "yellow")
+        assert logger.level_to_str(
+            mylog.Level.warn
+        ) == termcolor.colored("WARNING".ljust(8), "yellow")
+        assert logger.level_to_str(
+            mylog.Level.error
+        ) == termcolor.colored("ERROR".ljust(8), "red")
+        assert logger.level_to_str(
+            mylog.Level.critical
+        ) == termcolor.colored(
+            "CRITICAL".ljust(8),
+            "red",
+            "on_yellow",
+            ["bold", "underline", "blink"],
+        )
+        assert logger.level_to_str(
+            mylog.Level.fatal
+        ) == termcolor.colored(
+            "CRITICAL".ljust(8),
+            "red",
+            "on_yellow",
+            ["bold", "underline", "blink"],
+        )
+        nli = _random_nonlevel_int()
+        assert logger.level_to_str(nli) == str(nli).ljust(8)
 
-    def test_enabled(self):
-        mylogger = self.logger_factory()
-        mylogger.enabled = False
+    @staticmethod
+    def test_format_msg():
+        logger = mylog.root
+        lvl = _random_level()
+        # Check if it runs
+        for _ in range(10):
+            logger.format_msg(
+                lvl[0],
+                random_anything(),
+                False,
+                _randint(0, 3),
+            )
+        with pytest.warns(
+            UserWarning, match="No traceback available, but tb=True"
+        ):
+            logger.format_msg(
+                lvl[0],
+                random_anything(),
+                True,
+                _randint(0, 3),
+            )
 
-        stuff = str(anyting_except("{NULL}"))
-        mylogger.critical(stuff)
+    @staticmethod
+    def test_actually_log():
+        skip_if_slow()
 
-        assert mylogger.list == []
+        logger = mylog.root
+        logger.list = []
+        logger.indent = _randint(0, 10)
+        logger.stream = open(os.devnull, "w")
+        lvl = _random_level()
+        msg = random_anything()
+        frame_depth = _randint(0, 3)
 
-    def test_propagate(self):
-        mylogger = self.logger_factory()
-        mylogger.propagate = True
-        mylog.root.format_msg = no_format_msg
+        time = get_unix_time()
+        logger._actually_log(lvl[0], msg, frame_depth, False)
 
-        stuff = str(anyting_except("{NULL}"))
-        mylogger.critical(stuff)
+        assert len(logger.list) == 1
+        event = logger.list[0]
+        assert event.msg == str(msg)
+        assert event.level == lvl[1]
+        assert event.time == pytest.approx(time, rel=1)
+        assert event.indent == logger.indent
+        assert event.frame_depth == frame_depth
 
-        assert mylogger.list == []
-        assert len(mylogger.higher.list) == 1
-        logevent = mylogger.higher.list[0]
-        self.check_log_event(logevent, stuff)
+    @staticmethod
+    def test_log_propagate():
+        skip_if_slow()
 
-    def test_enabled_for(self):
-        mylogger = self.logger_factory()
-        mylogger.threshold = mylog.Level.critical
+        logger = mylog.root.get_child()
+        logger.list = []
+        logger.indent = _randint(0, 10)
+        logger.propagate = True
+        logger.stream = open(os.devnull, "w")
+        logger.threshold = mylog.Level.debug
+        logger.higher.stream = open(os.devnull, "w")
+        logger.higher.threshold = mylog.Level.debug
+        lvl = _random_level()
+        msg = random_anything()
+        frame_depth = _randint(0, 3)
 
-        mylogger.debug(str(anyting_except("{NULL}")))
+        time = get_unix_time()
+        logger._log(lvl[0], msg, False, frame_depth)
 
-        assert mylogger.list == []
+        assert not logger.list
+        event = logger.higher.list[-1]
+        assert event.msg == str(msg)
+        assert event.level == lvl[1]
+        assert event.time == pytest.approx(time, rel=1)
+        assert event.indent == logger.higher.indent
+        assert event.frame_depth == frame_depth + 1
+        #                                       ~~~
+        # Since propagate is True, Logger._log() will automatically add one to
+        # the frame_depth, if logging is done by the parent.
 
-    def test_is_enabled_for(self):
-        mylogger = self.logger_factory()
-        mylogger.threshold = mylog.Level.critical
-        assert mylogger.is_enabled_for(mylog.Level.critical) is True
-        assert mylogger.is_enabled_for(mylog.Level.error) is False
-        assert mylogger.is_enabled_for(mylog.Level.warning) is False
-        assert mylogger.is_enabled_for(mylog.Level.info) is False
-        assert mylogger.is_enabled_for(mylog.Level.debug) is False
+    @staticmethod
+    def test_log_no_propagate():
+        logger = mylog.root
+        logger.list = []
+        logger.indent = _randint(0, 10)
+        logger.threshold = mylog.Level.debug
+        logger.stream = open(os.devnull, "w")
+        lvl = _random_level()
+        msg = random_anything()
+        frame_depth = _randint(0, 3)
 
-        mylogger.threshold = mylog.Level.error
-        assert mylogger.is_enabled_for(mylog.Level.critical) is True
-        assert mylogger.is_enabled_for(mylog.Level.error) is True
-        assert mylogger.is_enabled_for(mylog.Level.warning) is False
-        assert mylogger.is_enabled_for(mylog.Level.info) is False
-        assert mylogger.is_enabled_for(mylog.Level.debug) is False
+        time = get_unix_time()
+        logger._log(lvl[0], msg, False, frame_depth)
 
-        mylogger.threshold = mylog.Level.warning
-        assert mylogger.is_enabled_for(mylog.Level.critical) is True
-        assert mylogger.is_enabled_for(mylog.Level.error) is True
-        assert mylogger.is_enabled_for(mylog.Level.warning) is True
-        assert mylogger.is_enabled_for(mylog.Level.info) is False
-        assert mylogger.is_enabled_for(mylog.Level.debug) is False
+        assert len(logger.list) == 1
+        event = logger.list[-1]
+        assert event.msg == str(msg)
+        assert event.level == lvl[1]
+        assert event.time == pytest.approx(time, rel=1)
+        assert event.indent == logger.indent
+        assert event.frame_depth == frame_depth
 
-        mylogger.threshold = mylog.Level.info
-        assert mylogger.is_enabled_for(mylog.Level.critical) is True
-        assert mylogger.is_enabled_for(mylog.Level.error) is True
-        assert mylogger.is_enabled_for(mylog.Level.warning) is True
-        assert mylogger.is_enabled_for(mylog.Level.info) is True
-        assert mylogger.is_enabled_for(mylog.Level.debug) is False
+    @staticmethod
+    @pytest.mark.parametrize(
+        "method_name,lvl",
+        [
+            ("debug", mylog.Level.debug),
+            ("info", mylog.Level.info),
+            ("warning", mylog.Level.warning),
+            ("error", mylog.Level.error),
+            ("critical", mylog.Level.critical),
+        ],
+    )
+    def test_log_methods(method_name: str, lvl: mylog.Level):
+        logger = mylog.root
+        logger.list = []
+        logger.indent = _randint(0, 10)
+        logger.threshold = mylog.Level.debug
+        logger.stream = open(os.devnull, "w")
+        msg = random_anything()
 
-        mylogger.threshold = mylog.Level.debug
-        assert mylogger.is_enabled_for(mylog.Level.critical) is True
-        assert mylogger.is_enabled_for(mylog.Level.error) is True
-        assert mylogger.is_enabled_for(mylog.Level.warning) is True
-        assert mylogger.is_enabled_for(mylog.Level.info) is True
-        assert mylogger.is_enabled_for(mylog.Level.debug) is True
+        time = get_unix_time()
+        getattr(logger, method_name)(msg, False)
 
-    def check_log_event(self, logevent, stuff):
-        assert logevent.msg == stuff
-        assert logevent.level == mylog.Level.critical
-        assert logevent.indent == 0
+        assert len(logger.list) == 1
+        event = logger.list[-1]
+        assert event.msg == str(msg)
+        assert event.level == lvl
+        assert event.time == pytest.approx(time, rel=1)
+        assert event.indent == logger.indent
+
+    @staticmethod
+    def test_get_child():
+        parent = mylog.root
+        child = parent.get_child()
+
+        assert isinstance(child, type(parent))
+        assert child.propagate is False
+        assert isinstance(child.lock, mylog.Lock)
+        assert child.list == []
+        assert child.indent == 0
+        assert child.enabled is True
+
+        assert child.format == parent.format
+        assert child.threshold == parent.threshold
+        assert child.stream == parent.stream
+
+    @staticmethod
+    def test_is_enabled_for():
+        logger = mylog.root
+
+        logger.threshold = mylog.Level.debug
+        assert logger.is_enabled_for(mylog.Level.debug)
+        assert logger.is_enabled_for(mylog.Level.info)
+        assert logger.is_enabled_for(mylog.Level.warning)
+        assert logger.is_enabled_for(mylog.Level.error)
+        assert logger.is_enabled_for(mylog.Level.critical)
+
+        logger.threshold = mylog.Level.info
+        assert not logger.is_enabled_for(mylog.Level.debug)
+        assert logger.is_enabled_for(mylog.Level.info)
+        assert logger.is_enabled_for(mylog.Level.warning)
+        assert logger.is_enabled_for(mylog.Level.error)
+        assert logger.is_enabled_for(mylog.Level.critical)
+
+        logger.threshold = mylog.Level.warning
+        assert not logger.is_enabled_for(mylog.Level.debug)
+        assert not logger.is_enabled_for(mylog.Level.info)
+        assert logger.is_enabled_for(mylog.Level.warning)
+        assert logger.is_enabled_for(mylog.Level.error)
+        assert logger.is_enabled_for(mylog.Level.critical)
+
+        logger.threshold = mylog.Level.error
+        assert not logger.is_enabled_for(mylog.Level.debug)
+        assert not logger.is_enabled_for(mylog.Level.info)
+        assert not logger.is_enabled_for(mylog.Level.warning)
+        assert logger.is_enabled_for(mylog.Level.error)
+        assert logger.is_enabled_for(mylog.Level.critical)
+
+        logger.threshold = mylog.Level.critical
+        assert not logger.is_enabled_for(mylog.Level.debug)
+        assert not logger.is_enabled_for(mylog.Level.info)
+        assert not logger.is_enabled_for(mylog.Level.warning)
+        assert not logger.is_enabled_for(mylog.Level.error)
+        assert logger.is_enabled_for(mylog.Level.critical)
 
 
-def test_indent():
-    mylogger = mylog.root.get_child()
-    assert mylogger.get_indent() == 0
-    with mylogger.ctxmgr:
-        assert mylogger.get_indent() == 1
-    assert mylogger.get_indent() == 0
+def test_indent_logger():
+    logger = mylog.root
+    start = _randint(0, 6)
+    logger.indent = start
+
+    with logger.ctxmgr:
+        assert logger.indent == start + 1
+
+    assert logger.indent == start
 
 
 def test_change_threshold():
-    mylogger = mylog.root.get_child()
-    assert mylogger.get_effective_level() == mylog.DEFAULT_THRESHOLD
-    with mylog.ChangeThreshold(mylogger, 30):
-        assert mylogger.get_effective_level() == mylog.Level.warning
-    assert mylogger.get_effective_level() == mylog.DEFAULT_THRESHOLD
+    logger = mylog.root
+    start = _random_level()
+    new = _random_level()
+    logger.threshold = start[1]
+
+    with mylog.ChangeThreshold(logger, new[0]):
+        assert logger.threshold == new[1]
+
+    assert logger.threshold == start[1]

--- a/tests/test_mylog.py
+++ b/tests/test_mylog.py
@@ -22,7 +22,7 @@ def _randint(a: int, b: int) -> int:
 def _randbytes(length: int) -> bytes:
     # random.randbytes is used only here,
     # so we have to use "nosec" only once
-    return secrets.SystemRandom().randbytes(length)  # nosec B311
+    return secrets.token_bytes(length)  # nosec B311
 
 
 def _randchoice(seq: Sequence[T]) -> T:


### PR DESCRIPTION
# 0.2.0 - 2022-04-23

### Added

- **A `UserWarning` is issued, if a log function is called with `traceback=True` (or `tb=True`) but there's _no_ exception.**
- **`Logger.is_enabled_for` issues a `UserWarning`, if `Logger.threshold` is not a `Level`, and it tries to convert it.**

### Changed

- **Changed how inheritence works**
- Protocols are now runtime checkable.

### Removed

- **! Because inheritence changed, most of the `get_*` methods were _removed_.**
