### PR TITLE
0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2022-05-06
+
+_Changed from pre-releases are listed here._
+
+### Added
+
+- **A `UserWarning` is issued, if a log function is called with `traceback=True` (or `tb=True`) but there's _no_ exception.**
+- **`Logger.is_enabled_for` issues a `UserWarning`, if `Logger.threshold` is not a `Level`, and it tries to convert it.**
+
+### Changed
+
+- **Changed how inheritence works**
+- Protocols are now runtime checkable.
+- Specified requirements/dependencies in `setup.cfg` too.
+
+### Removed
+
+- **! Because inheritence changed, most of the `get_*` methods were _removed_.**
+
 ## [0.2.0-beta.1] - 2022-04-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,13 +18,13 @@ _Changed from pre-releases are listed here._
 
 ### Changed
 
-- **Changed how inheritence works**
+- **Changed how inheritance works**
 - Protocols are now runtime checkable.
 - Specified requirements/dependencies in `setup.cfg` too.
 
 ### Removed
 
-- **! Because inheritence changed, most of the `get_*` methods were _removed_.**
+- **! Because inheritance changed, most of the `get_*` methods were _removed_.**
 
 ## [0.2.0-beta.1] - 2022-04-22
 
@@ -35,12 +35,12 @@ _Changed from pre-releases are listed here._
 
 ### Changed
 
-- **Changed how inheritence works**
+- **Changed how inheritance works**
 - Protocols are now runtime checkable.
 
 ### Removed
 
-- **! Because inheritence changed, most of the `get_*` methods were _removed_.**
+- **! Because inheritance changed, most of the `get_*` methods were _removed_.**
 
 ## [0.1.1] - 2022-03-27
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,6 @@ packages =
 install_requires =
     termcolor==1.1.0
     typing-extensions==4.1.1
-
 python_requires = >=3.8
 package_dir =
     =src

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,9 @@ keywords = logger, log
 packages =
     mylog
 install_requires =
-    termcolor~=1.1.0
+    termcolor==1.1.0
+    typing-extensions==4.1.1
+
 python_requires = >=3.8
 package_dir =
     =src

--- a/src/mylog/__init__.py
+++ b/src/mylog/__init__.py
@@ -190,10 +190,7 @@ def is_union(union: Any) -> bool:
         bool: True if `union` is a Union, False otherwise.
     """
     try:
-        return (
-            (type(union) is Union)
-            or (union.__origin__ is Union)
-        )
+        return (type(union) is Union) or (union.__origin__ is Union)
     except AttributeError:
         return False
 
@@ -289,6 +286,7 @@ class Logger:
         self.list: List[LogEvent] = []
         self.indent = 0  # Should be set manually
         self.enabled: bool = True
+        self.ctxmgr = IndentLogger(self)
 
         # These (in my opinion) should be inherited.
         self.format: str = self.higher.format
@@ -644,10 +642,7 @@ class Logger:
         # This function should be short, so if the user doesn't like it, it
         # can be copy-pasted, and the user can change it.
         # (That's why we have `._inherit`)
-        cls: Type[Logger] = type(self)
-        rv = cls(self)
-        rv._inherit(None)
-        return rv
+        return type(self)(self)
 
     def is_enabled_for(self, lvl: Levelable) -> bool:
         """


### PR DESCRIPTION
## [0.2.0] - 2022-05-06

_Changed from pre-releases are listed here._

### Added

- **A `UserWarning` is issued, if a log function is called with `traceback=True` (or `tb=True`) but there's _no_ exception.**
- **`Logger.is_enabled_for` issues a `UserWarning`, if `Logger.threshold` is not a `Level`, and it tries to convert it.**

### Changed

- **Changed how inheritance works**
- Protocols are now runtime checkable.
- Specified requirements/dependencies in `setup.cfg` too.

### Removed

- **! Because inheritance changed, most of the `get_*` methods were _removed_.**